### PR TITLE
Use npx to invoke npm-check-updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@commitlint/cli": "17.5.1",
-        "@commitlint/config-conventional": "17.4.4",
+        "@commitlint/cli": "17.6.1",
+        "@commitlint/config-conventional": "17.6.1",
         "@docusaurus/core": "2.4.0",
         "@docusaurus/preset-classic": "2.4.0",
         "@mdx-js/react": "1.6.21",
-        "@snyk/protect": "1.1140.0",
+        "@snyk/protect": "1.1143.0",
         "clsx": "1.2.1",
         "husky": "8.0.3",
         "jest": "29.5.0",
@@ -1989,12 +1989,12 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.5.1.tgz",
-      "integrity": "sha512-pRRgGSzdHQHehxZbGA3qF6wVPyl+EEQgTe/t321rtMLFbuJ7nRj2waS17s/v5oEbyZtiY5S8PGB6XtEIm0I+Sg==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.1.tgz",
+      "integrity": "sha512-kCnDD9LE2ySiTnj/VPaxy4/oRayRcdv4aCuVxtoum8SxIU7OADHc0nJPQfheE8bHcs3zZdWzDMWltRosuT13bg==",
       "dependencies": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.4.4",
+        "@commitlint/lint": "^17.6.1",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -2012,9 +2012,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
-      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.6.1.tgz",
+      "integrity": "sha512-ng/ybaSLuTCH9F+7uavSOnEQ9EFMl7lHEjfAEgRh1hwmEe8SpLKpQeMo2aT1IWvHaGMuTb+gjfbzoRf2IR23NQ==",
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
       },
@@ -2083,13 +2083,13 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.4.tgz",
-      "integrity": "sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.1.tgz",
+      "integrity": "sha512-VARJ9kxH64isgwVnC+ABPafCYzqxpsWJIpDaTuI0gh8aX4GQ0i7cn9tvxtFNfJj4ER2BAJeWJ0vURdNYjK2RQQ==",
       "dependencies": {
         "@commitlint/is-ignored": "^17.4.4",
         "@commitlint/parse": "^17.4.4",
-        "@commitlint/rules": "^17.4.4",
+        "@commitlint/rules": "^17.6.1",
         "@commitlint/types": "^17.4.4"
       },
       "engines": {
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.4.tgz",
-      "integrity": "sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.1.tgz",
+      "integrity": "sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==",
       "dependencies": {
         "@commitlint/ensure": "^17.4.4",
         "@commitlint/message": "^17.4.2",
@@ -3808,9 +3808,9 @@
       }
     },
     "node_modules/@snyk/protect": {
-      "version": "1.1140.0",
-      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1140.0.tgz",
-      "integrity": "sha512-xs882A4lC3ICCKgXOzV42Mjj6ZDNF3UpUmfJIeKIcfoyICR5BCrszLaL6l/6jdGUixdyxLjzv4EGRVOxVvNKbw==",
+      "version": "1.1143.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1143.0.tgz",
+      "integrity": "sha512-lNicqdpJbvIBHw5JS8CF26RRhKKlg0h5Wez6t/aIeMB6QqBeI0qFt2Eb8MVyC3sUew++q2nCFwydhLw+wSMb2Q==",
       "bin": {
         "snyk-protect": "bin/snyk-protect"
       },
@@ -19235,12 +19235,12 @@
       "optional": true
     },
     "@commitlint/cli": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.5.1.tgz",
-      "integrity": "sha512-pRRgGSzdHQHehxZbGA3qF6wVPyl+EEQgTe/t321rtMLFbuJ7nRj2waS17s/v5oEbyZtiY5S8PGB6XtEIm0I+Sg==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.1.tgz",
+      "integrity": "sha512-kCnDD9LE2ySiTnj/VPaxy4/oRayRcdv4aCuVxtoum8SxIU7OADHc0nJPQfheE8bHcs3zZdWzDMWltRosuT13bg==",
       "requires": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.4.4",
+        "@commitlint/lint": "^17.6.1",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -19252,9 +19252,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
-      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.6.1.tgz",
+      "integrity": "sha512-ng/ybaSLuTCH9F+7uavSOnEQ9EFMl7lHEjfAEgRh1hwmEe8SpLKpQeMo2aT1IWvHaGMuTb+gjfbzoRf2IR23NQ==",
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
       }
@@ -19305,13 +19305,13 @@
       }
     },
     "@commitlint/lint": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.4.tgz",
-      "integrity": "sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.1.tgz",
+      "integrity": "sha512-VARJ9kxH64isgwVnC+ABPafCYzqxpsWJIpDaTuI0gh8aX4GQ0i7cn9tvxtFNfJj4ER2BAJeWJ0vURdNYjK2RQQ==",
       "requires": {
         "@commitlint/is-ignored": "^17.4.4",
         "@commitlint/parse": "^17.4.4",
-        "@commitlint/rules": "^17.4.4",
+        "@commitlint/rules": "^17.6.1",
         "@commitlint/types": "^17.4.4"
       }
     },
@@ -19377,9 +19377,9 @@
       }
     },
     "@commitlint/rules": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.4.tgz",
-      "integrity": "sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.6.1.tgz",
+      "integrity": "sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==",
       "requires": {
         "@commitlint/ensure": "^17.4.4",
         "@commitlint/message": "^17.4.2",
@@ -20637,9 +20637,9 @@
       }
     },
     "@snyk/protect": {
-      "version": "1.1140.0",
-      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1140.0.tgz",
-      "integrity": "sha512-xs882A4lC3ICCKgXOzV42Mjj6ZDNF3UpUmfJIeKIcfoyICR5BCrszLaL6l/6jdGUixdyxLjzv4EGRVOxVvNKbw=="
+      "version": "1.1143.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1143.0.tgz",
+      "integrity": "sha512-lNicqdpJbvIBHw5JS8CF26RRhKKlg0h5Wez6t/aIeMB6QqBeI0qFt2Eb8MVyC3sUew++q2nCFwydhLw+wSMb2Q=="
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "deps:upgrade": "npx npm-check-updates -- -u"
   },
   "dependencies": {
-    "@commitlint/cli": "17.5.1",
-    "@commitlint/config-conventional": "17.4.4",
+    "@commitlint/cli": "17.6.1",
+    "@commitlint/config-conventional": "17.6.1",
     "@docusaurus/core": "2.4.0",
     "@docusaurus/preset-classic": "2.4.0",
     "@mdx-js/react": "1.6.21",
-    "@snyk/protect": "1.1140.0",
+    "@snyk/protect": "1.1143.0",
     "clsx": "1.2.1",
     "husky": "8.0.3",
     "jest": "29.5.0",


### PR DESCRIPTION
## Description

Following Ulises suggestion, we use npx to invoke npm-check-updates instead of installing it locally.

Also, dependencies have been updated,

## Related Issue

https://github.com/onebeyond/maintainers/pull/66#discussion_r1163837457

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
